### PR TITLE
Re-export Concurrently constructor together with runConcurrently.

### DIFF
--- a/src/Control/Concurrent/Async/Lifted.hs
+++ b/src/Control/Concurrent/Async/Lifted.hs
@@ -40,7 +40,7 @@ module Control.Concurrent.Async.Lifted
 
     -- ** Convenient utilities
   , race, race_, concurrently, mapConcurrently
-  , A.Concurrently, A.runConcurrently
+  , A.Concurrently (..)
   ) where
 
 import Control.Monad ((>=>), liftM, void)


### PR DESCRIPTION
It looks like an oversight that the `Concurrently` constructor is not re-exported, which can be a minor inconvenience.
