### PR TITLE
Fix 7.10 build

### DIFF
--- a/src/Control/Concurrent/Async/Lifted.hs
+++ b/src/Control/Concurrent/Async/Lifted.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE ImpredicativeTypes #-}
 {-# LANGUAGE KindSignatures #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE TypeFamilies #-}

--- a/src/Control/Concurrent/Async/Lifted/Safe.hs
+++ b/src/Control/Concurrent/Async/Lifted/Safe.hs
@@ -3,6 +3,7 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GADTs #-}
+{-# LANGUAGE ImpredicativeTypes #-}
 {-# LANGUAGE KindSignatures #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE RankNTypes #-}


### PR DESCRIPTION
Under 7.10 the build was failing with the following error
```
src/Control/Concurrent/Async/Lifted.hs:384:26:
    Cannot instantiate unification variable ‘b0’
    with a type involving foralls: forall a1. m a1 -> IO (StM m a1)
      Perhaps you want ImpredicativeTypes
    In the first argument of ‘(.)’, namely ‘liftBaseWith’
    In the second argument of ‘(.)’, namely ‘liftBaseWith . const’
```

For some unknown reason the previous build with 7.10 on CI (https://travis-ci.org/maoe/lifted-async/jobs/56357141) is working, but I've been getting this error with ghc build from 7.10 branch.