### PR TITLE
Added forConcurrently, minor version bump

### DIFF
--- a/src/Control/Concurrent/Async/Lifted.hs
+++ b/src/Control/Concurrent/Async/Lifted.hs
@@ -53,7 +53,7 @@ module Control.Concurrent.Async.Lifted
   , link, link2
 
     -- * Convenient utilities
-  , race, race_, concurrently, mapConcurrently
+  , race, race_, concurrently, mapConcurrently, forConcurrently
   , Concurrently(..)
   ) where
 
@@ -351,6 +351,14 @@ mapConcurrently
   -> t a
   -> m (t b)
 mapConcurrently f = runConcurrently . traverse (Concurrently . f)
+
+-- | Generalized version of 'A.forConcurrently'.
+forConcurrently
+  :: (Traversable t, MonadBaseControl IO m)
+  => t a
+  -> (a -> m b)
+  -> m (t b)
+forConcurrently = flip mapConcurrently
 
 -- | Generalized version of 'A.Concurrently'.
 --


### PR DESCRIPTION
https://github.com/simonmar/async/pull/30 -- Marlow approved ! 

Defined it in terms of `mapConcurrently` from `lifted-async`, not `async`. This way the async lower bound won't have to be raised.