### PR TITLE
Add concurrently_ to match non-lifted async library

### DIFF
--- a/lifted-async.cabal
+++ b/lifted-async.cabal
@@ -36,7 +36,7 @@ library
     Control.Concurrent.Async.Lifted.Safe
   build-depends:
       base >= 4.5 && < 4.11
-    , async >= 2.0.1 && < 2.2
+    , async >= 2.1.1 && < 2.2
     , lifted-base >= 0.2 && < 0.3
     , transformers-base >= 0.4 && < 0.5
   if flag(monad-control-1)

--- a/src/Control/Concurrent/Async/Lifted.hs
+++ b/src/Control/Concurrent/Async/Lifted.hs
@@ -363,7 +363,7 @@ concurrently left right =
 {-# INLINABLE concurrently #-}
 
 concurrently_ :: MonadBaseControl IO m => m a -> m b -> m ()
-concurrently_ left right = concurrently left right >> return ()
+concurrently_ left right = void $ concurrently left right
 {-# INLINABLE concurrently_ #-}
 
 -- | Generalized version of 'A.mapConcurrently'.

--- a/src/Control/Concurrent/Async/Lifted.hs
+++ b/src/Control/Concurrent/Async/Lifted.hs
@@ -63,7 +63,7 @@ module Control.Concurrent.Async.Lifted
   , link, link2
 
     -- * Convenient utilities
-  , race, race_, concurrently
+  , race, race_, concurrently, concurrently_
   , mapConcurrently, mapConcurrently_
   , forConcurrently, forConcurrently_
   , Concurrently(..)
@@ -361,6 +361,10 @@ concurrently left right =
   withAsync right $ \b ->
   waitBoth a b
 {-# INLINABLE concurrently #-}
+
+concurrently_ :: MonadBaseControl IO m => m a -> m b -> m ()
+concurrently_ left right = concurrently left right >> return ()
+{-# INLINABLE concurrently_ #-}
 
 -- | Generalized version of 'A.mapConcurrently'.
 mapConcurrently

--- a/src/Control/Concurrent/Async/Lifted/Safe.hs
+++ b/src/Control/Concurrent/Async/Lifted/Safe.hs
@@ -330,7 +330,7 @@ concurrently = liftBaseOp2_ A.concurrently
 concurrently_
   :: forall m a b. (MonadBaseControl IO m, Forall (Pure m))
   => m a -> m b -> m ()
-concurrently_ left right = void $ concurrently left right
+concurrently_ = liftBaseOp2_ A.concurrently_
 
 -- | Similar to 'A.liftBaseOp_' but takes a binary function
 -- and leverages @'StM' m a ~ a@.

--- a/src/Control/Concurrent/Async/Lifted/Safe.hs
+++ b/src/Control/Concurrent/Async/Lifted/Safe.hs
@@ -67,7 +67,7 @@ module Control.Concurrent.Async.Lifted.Safe
   , Unsafe.link, Unsafe.link2
 
     -- * Convenient utilities
-  , race, race_, concurrently
+  , race, race_, concurrently, concurrently_
   , mapConcurrently, mapConcurrently_
   , forConcurrently, forConcurrently_
   , Concurrently(..)
@@ -326,6 +326,11 @@ concurrently
   :: forall m a b. (MonadBaseControl IO m, Forall (Pure m))
   => m a -> m b -> m (a, b)
 concurrently = liftBaseOp2_ A.concurrently
+
+concurrently_
+  :: forall m a b. (MonadBaseControl IO m, Forall (Pure m))
+  => m a -> m b -> m ()
+concurrently_ left right = void $ concurrently left right
 
 -- | Similar to 'A.liftBaseOp_' but takes a binary function
 -- and leverages @'StM' m a ~ a@.


### PR DESCRIPTION
I was using `concurrently_` from the non-lifted library, and found it missing when I switched to `lifted-async`. This is a quick stab at implementing a version!