### PR TITLE
Allow building with base-4.11

### DIFF
--- a/lifted-async.cabal
+++ b/lifted-async.cabal
@@ -29,7 +29,7 @@ library
     Control.Concurrent.Async.Lifted
     Control.Concurrent.Async.Lifted.Safe
   build-depends:
-      base >= 4.5 && < 4.11
+      base >= 4.5 && < 4.12
     , async >= 2.2 && < 2.3
     , lifted-base >= 0.2 && < 0.3
     , transformers-base >= 0.4 && < 0.5


### PR DESCRIPTION
`lifted-async` builds without issue on `base-4.11` (bundled with GHC 8.4.1).