### PR TITLE
Fix typechecking errors with GHC head (8.11)

### DIFF
--- a/src/Control/Concurrent/Async/Lifted.hs
+++ b/src/Control/Concurrent/Async/Lifted.hs
@@ -448,7 +448,7 @@ instance MonadBaseControl IO m => Applicative (Concurrently m) where
     Concurrently $ uncurry ($) <$> concurrently fs as
 
 instance MonadBaseControl IO m => Alternative (Concurrently m) where
-  empty = Concurrently $ liftBaseWith $ const (forever $ threadDelay maxBound)
+  empty = Concurrently $ liftBaseWith $ \_ -> forever $ threadDelay maxBound
   Concurrently as <|> Concurrently bs =
     Concurrently $ either id id <$> race as bs
 

--- a/src/Control/Concurrent/Async/Lifted/Safe.hs
+++ b/src/Control/Concurrent/Async/Lifted/Safe.hs
@@ -432,7 +432,7 @@ instance (MonadBaseControl IO m, Forall (Pure m)) =>
 
 instance (MonadBaseControl IO m, Forall (Pure m)) =>
   Alternative (Concurrently m) where
-    empty = Concurrently $ liftBaseWith $ const (forever $ threadDelay maxBound)
+    empty = Concurrently $ liftBaseWith $ \_ -> forever $ threadDelay maxBound
     Concurrently (as :: m a) <|> Concurrently bs =
       Concurrently (either id id <$> race as bs)
         \\ (inst :: Forall (Pure m) :- Pure m a)


### PR DESCRIPTION
Without this, GHC says:
```
 /home/centos/lifted-async/src/Control/Concurrent/Async/Lifted.hs:451:41: error:
     • Couldn't match type ‘b0’ with ‘forall a. m a -> IO (StM m a)’
       Expected: RunInBase m IO -> IO a
         Actual: b0 -> IO a
       Cannot instantiate unification variable ‘b0’
       with a type involving polytypes: forall a. m a -> IO (StM m a)
     • In the second argument of ‘($)’, namely
         ‘const (forever $ threadDelay maxBound)’
       In the second argument of ‘($)’, namely
         ‘liftBaseWith $ const (forever $ threadDelay maxBound)’
       In the expression:
         Concurrently
           $ liftBaseWith $ const (forever $ threadDelay maxBound)
     • Relevant bindings include
         empty :: Concurrently m a
           (bound at src/Control/Concurrent/Async/Lifted.hs:451:3)
     |             
 451 |   empty = Concurrently $ liftBaseWith $ const (forever $ threadDelay m
axBound)
     | 
```