### PR TITLE
Allow base-4.21, tasty-bench-0.4, bump Haskell CI to GHC 9.12.0

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -8,9 +8,9 @@
 #
 # For more information, see https://github.com/andreasabel/haskell-ci
 #
-# version: 0.19.20240703
+# version: 0.19.20241021
 #
-# REGENDATA ("0.19.20240703",["github","lifted-async.cabal"])
+# REGENDATA ("0.19.20241021",["github","lifted-async.cabal"])
 #
 name: Haskell-CI
 on:
@@ -36,6 +36,11 @@ jobs:
     strategy:
       matrix:
         include:
+          - compiler: ghc-9.12.20241014
+            compilerKind: ghc
+            compilerVersion: 9.12.20241014
+            setup-method: ghcup
+            allow-failure: false
           - compiler: ghc-9.10.1
             compilerKind: ghc
             compilerVersion: 9.10.1
@@ -103,8 +108,9 @@ jobs:
           apt-get update
           apt-get install -y --no-install-recommends gnupg ca-certificates dirmngr curl git software-properties-common libtinfo5 libnuma-dev
           mkdir -p "$HOME/.ghcup/bin"
-          curl -sL https://downloads.haskell.org/ghcup/0.1.20.0/x86_64-linux-ghcup-0.1.20.0 > "$HOME/.ghcup/bin/ghcup"
+          curl -sL https://downloads.haskell.org/ghcup/0.1.30.0/x86_64-linux-ghcup-0.1.30.0 > "$HOME/.ghcup/bin/ghcup"
           chmod a+x "$HOME/.ghcup/bin/ghcup"
+          "$HOME/.ghcup/bin/ghcup" config add-release-channel https://raw.githubusercontent.com/haskell/ghcup-metadata/master/ghcup-prereleases-0.0.8.yaml;
           "$HOME/.ghcup/bin/ghcup" install ghc "$HCVER" || (cat "$HOME"/.ghcup/logs/*.* && false)
           "$HOME/.ghcup/bin/ghcup" install cabal 3.12.1.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
         env:
@@ -129,7 +135,7 @@ jobs:
           echo "HCNUMVER=$HCNUMVER" >> "$GITHUB_ENV"
           echo "ARG_TESTS=--enable-tests" >> "$GITHUB_ENV"
           echo "ARG_BENCH=--enable-benchmarks" >> "$GITHUB_ENV"
-          echo "HEADHACKAGE=false" >> "$GITHUB_ENV"
+          if [ $((HCNUMVER >= 91200)) -ne 0 ] ; then echo "HEADHACKAGE=true" >> "$GITHUB_ENV" ; else echo "HEADHACKAGE=false" >> "$GITHUB_ENV" ; fi
           echo "ARG_COMPILER=--$HCKIND --with-compiler=$HC" >> "$GITHUB_ENV"
           echo "GHCJSARITH=0" >> "$GITHUB_ENV"
         env:
@@ -158,6 +164,18 @@ jobs:
           repository hackage.haskell.org
             url: http://hackage.haskell.org/
           EOF
+          if $HEADHACKAGE; then
+          cat >> $CABAL_CONFIG <<EOF
+          repository head.hackage.ghc.haskell.org
+             url: https://ghc.gitlab.haskell.org/head.hackage/
+             secure: True
+             root-keys: 7541f32a4ccca4f97aea3b22f5e593ba2c0267546016b992dfadcd2fe944e55d
+                        26021a13b401500c8eb2761ca95c61f2d625bfef951b939a8124ed12ecf07329
+                        f76d08be13e9a61a377a85e2fb63f4c5435d40f8feb3e12eb05905edb8cdea89
+             key-threshold: 3
+          active-repositories: hackage.haskell.org, head.hackage.ghc.haskell.org:override
+          EOF
+          fi
           cat >> $CABAL_CONFIG <<EOF
           program-default-options
             ghc-options: $GHCJOBS +RTS -M3G -RTS
@@ -209,6 +227,9 @@ jobs:
           if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then echo "    ghc-options: -Werror=missing-methods" >> cabal.project ; fi
           cat >> cabal.project <<EOF
           EOF
+          if $HEADHACKAGE; then
+          echo "allow-newer: $($HCPKG list --simple-output | sed -E 's/([a-zA-Z-]+)-[0-9.]+/*:\1,/g')" >> cabal.project
+          fi
           $HCPKG list --simple-output --names-only | perl -ne 'for (split /\s+/) { print "constraints: any.$_ installed\n" unless /^(lifted-async)$/; }' >> cabal.project.local
           cat cabal.project
           cat cabal.project.local

--- a/lifted-async.cabal
+++ b/lifted-async.cabal
@@ -12,6 +12,7 @@ copyright:           Copyright (C) 2012-2024 Mitsutoshi Aoe
 category:            Concurrency
 build-type:          Simple
 tested-with:
+  GHC == 9.12.0
   GHC == 9.10.1
   GHC == 9.8.2
   GHC == 9.6.6
@@ -38,7 +39,7 @@ library
     Control.Concurrent.Async.Lifted
     Control.Concurrent.Async.Lifted.Safe
   build-depends:
-      base >= 4.5 && < 4.21
+      base >= 4.5 && < 4.22
     , async >= 2.2 && < 2.3
     , lifted-base >= 0.2 && < 0.3
     , transformers-base >= 0.4 && < 0.5
@@ -96,7 +97,7 @@ benchmark benchmark-lifted-async
   build-depends:
       base
     , async
-    , tasty-bench < 0.4
+    , tasty-bench < 0.5
     , deepseq
     , lifted-async
   default-language: Haskell2010
@@ -109,7 +110,7 @@ benchmark benchmark-lifted-async-threaded
   build-depends:
       base
     , async
-    , tasty-bench < 0.4
+    , tasty-bench < 0.5
     , deepseq
     , lifted-async
   default-language: Haskell2010


### PR DESCRIPTION
Closes #45.
- #45