### PR TITLE
Drop support for GHC 7, allow base-4.22, bump CI to GHC 9.14 alpha1

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -6,11 +6,11 @@
 #
 #   haskell-ci regenerate
 #
-# For more information, see https://github.com/andreasabel/haskell-ci
+# For more information, see https://github.com/haskell-CI/haskell-ci
 #
-# version: 0.19.20241021
+# version: 0.19.20250821
 #
-# REGENDATA ("0.19.20241021",["github","lifted-async.cabal"])
+# REGENDATA ("0.19.20250821",["github","lifted-async.cabal"])
 #
 name: Haskell-CI
 on:
@@ -27,7 +27,7 @@ on:
 jobs:
   linux:
     name: Haskell-CI - Linux - ${{ matrix.compiler }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     timeout-minutes:
       60
     container:
@@ -36,24 +36,29 @@ jobs:
     strategy:
       matrix:
         include:
-          - compiler: ghc-9.12.20241014
+          - compiler: ghc-9.14.0.20250819
             compilerKind: ghc
-            compilerVersion: 9.12.20241014
+            compilerVersion: 9.14.0.20250819
+            setup-method: ghcup-prerelease
+            allow-failure: false
+          - compiler: ghc-9.12.2
+            compilerKind: ghc
+            compilerVersion: 9.12.2
             setup-method: ghcup
             allow-failure: false
-          - compiler: ghc-9.10.1
+          - compiler: ghc-9.10.2
             compilerKind: ghc
-            compilerVersion: 9.10.1
+            compilerVersion: 9.10.2
             setup-method: ghcup
             allow-failure: false
-          - compiler: ghc-9.8.2
+          - compiler: ghc-9.8.4
             compilerKind: ghc
-            compilerVersion: 9.8.2
+            compilerVersion: 9.8.4
             setup-method: ghcup
             allow-failure: false
-          - compiler: ghc-9.6.6
+          - compiler: ghc-9.6.7
             compilerKind: ghc
-            compilerVersion: 9.6.6
+            compilerVersion: 9.6.7
             setup-method: ghcup
             allow-failure: false
           - compiler: ghc-9.4.8
@@ -103,16 +108,44 @@ jobs:
             allow-failure: false
       fail-fast: false
     steps:
-      - name: apt
+      - name: apt-get install
         run: |
           apt-get update
           apt-get install -y --no-install-recommends gnupg ca-certificates dirmngr curl git software-properties-common libtinfo5 libnuma-dev
+      - name: Install GHCup
+        run: |
           mkdir -p "$HOME/.ghcup/bin"
-          curl -sL https://downloads.haskell.org/ghcup/0.1.30.0/x86_64-linux-ghcup-0.1.30.0 > "$HOME/.ghcup/bin/ghcup"
+          curl -sL https://downloads.haskell.org/ghcup/0.1.50.1/x86_64-linux-ghcup-0.1.50.1 > "$HOME/.ghcup/bin/ghcup"
           chmod a+x "$HOME/.ghcup/bin/ghcup"
-          "$HOME/.ghcup/bin/ghcup" config add-release-channel https://raw.githubusercontent.com/haskell/ghcup-metadata/master/ghcup-prereleases-0.0.8.yaml;
+      - name: Install cabal-install
+        run: |
+          "$HOME/.ghcup/bin/ghcup" install cabal 3.16.0.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
+          echo "CABAL=$HOME/.ghcup/bin/cabal-3.16.0.0 -vnormal+nowrap" >> "$GITHUB_ENV"
+      - name: Install GHC (GHCup)
+        if: matrix.setup-method == 'ghcup'
+        run: |
           "$HOME/.ghcup/bin/ghcup" install ghc "$HCVER" || (cat "$HOME"/.ghcup/logs/*.* && false)
-          "$HOME/.ghcup/bin/ghcup" install cabal 3.12.1.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
+          HC=$("$HOME/.ghcup/bin/ghcup" whereis ghc "$HCVER")
+          HCPKG=$(echo "$HC" | sed 's#ghc$#ghc-pkg#')
+          HADDOCK=$(echo "$HC" | sed 's#ghc$#haddock#')
+          echo "HC=$HC" >> "$GITHUB_ENV"
+          echo "HCPKG=$HCPKG" >> "$GITHUB_ENV"
+          echo "HADDOCK=$HADDOCK" >> "$GITHUB_ENV"
+        env:
+          HCKIND: ${{ matrix.compilerKind }}
+          HCNAME: ${{ matrix.compiler }}
+          HCVER: ${{ matrix.compilerVersion }}
+      - name: Install GHC (GHCup prerelease)
+        if: matrix.setup-method == 'ghcup-prerelease'
+        run: |
+          "$HOME/.ghcup/bin/ghcup" config add-release-channel prereleases
+          "$HOME/.ghcup/bin/ghcup" install ghc "$HCVER" || (cat "$HOME"/.ghcup/logs/*.* && false)
+          HC=$("$HOME/.ghcup/bin/ghcup" whereis ghc "$HCVER")
+          HCPKG=$(echo "$HC" | sed 's#ghc$#ghc-pkg#')
+          HADDOCK=$(echo "$HC" | sed 's#ghc$#haddock#')
+          echo "HC=$HC" >> "$GITHUB_ENV"
+          echo "HCPKG=$HCPKG" >> "$GITHUB_ENV"
+          echo "HADDOCK=$HADDOCK" >> "$GITHUB_ENV"
         env:
           HCKIND: ${{ matrix.compilerKind }}
           HCNAME: ${{ matrix.compiler }}
@@ -123,21 +156,12 @@ jobs:
           echo "LANG=C.UTF-8" >> "$GITHUB_ENV"
           echo "CABAL_DIR=$HOME/.cabal" >> "$GITHUB_ENV"
           echo "CABAL_CONFIG=$HOME/.cabal/config" >> "$GITHUB_ENV"
-          HCDIR=/opt/$HCKIND/$HCVER
-          HC=$("$HOME/.ghcup/bin/ghcup" whereis ghc "$HCVER")
-          HCPKG=$(echo "$HC" | sed 's#ghc$#ghc-pkg#')
-          HADDOCK=$(echo "$HC" | sed 's#ghc$#haddock#')
-          echo "HC=$HC" >> "$GITHUB_ENV"
-          echo "HCPKG=$HCPKG" >> "$GITHUB_ENV"
-          echo "HADDOCK=$HADDOCK" >> "$GITHUB_ENV"
-          echo "CABAL=$HOME/.ghcup/bin/cabal-3.12.1.0 -vnormal+nowrap" >> "$GITHUB_ENV"
           HCNUMVER=$(${HC} --numeric-version|perl -ne '/^(\d+)\.(\d+)\.(\d+)(\.(\d+))?$/; print(10000 * $1 + 100 * $2 + ($3 == 0 ? $5 != 1 : $3))')
           echo "HCNUMVER=$HCNUMVER" >> "$GITHUB_ENV"
           echo "ARG_TESTS=--enable-tests" >> "$GITHUB_ENV"
           echo "ARG_BENCH=--enable-benchmarks" >> "$GITHUB_ENV"
-          if [ $((HCNUMVER >= 91200)) -ne 0 ] ; then echo "HEADHACKAGE=true" >> "$GITHUB_ENV" ; else echo "HEADHACKAGE=false" >> "$GITHUB_ENV" ; fi
+          if [ $((HCNUMVER >= 91400)) -ne 0 ] ; then echo "HEADHACKAGE=true" >> "$GITHUB_ENV" ; else echo "HEADHACKAGE=false" >> "$GITHUB_ENV" ; fi
           echo "ARG_COMPILER=--$HCKIND --with-compiler=$HC" >> "$GITHUB_ENV"
-          echo "GHCJSARITH=0" >> "$GITHUB_ENV"
         env:
           HCKIND: ${{ matrix.compilerKind }}
           HCNAME: ${{ matrix.compiler }}
@@ -224,7 +248,11 @@ jobs:
           touch cabal.project.local
           echo "packages: ${PKGDIR_lifted_async}" >> cabal.project
           if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then echo "package lifted-async" >> cabal.project ; fi
-          if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then echo "    ghc-options: -Werror=missing-methods" >> cabal.project ; fi
+          if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then echo "    ghc-options: -Werror=missing-methods -Werror=missing-fields" >> cabal.project ; fi
+          if [ $((HCNUMVER >= 90400)) -ne 0 ] ; then echo "package lifted-async" >> cabal.project ; fi
+          if [ $((HCNUMVER >= 90400)) -ne 0 ] ; then echo "    ghc-options: -Werror=unused-packages" >> cabal.project ; fi
+          if [ $((HCNUMVER >= 90000)) -ne 0 ] ; then echo "package lifted-async" >> cabal.project ; fi
+          if [ $((HCNUMVER >= 90000)) -ne 0 ] ; then echo "    ghc-options: -Werror=incomplete-patterns -Werror=incomplete-uni-patterns" >> cabal.project ; fi
           cat >> cabal.project <<EOF
           EOF
           if $HEADHACKAGE; then
@@ -268,8 +296,8 @@ jobs:
           rm -f cabal.project.local
           $CABAL v2-build $ARG_COMPILER --disable-tests --disable-benchmarks all
       - name: save cache
-        uses: actions/cache/save@v4
         if: always()
+        uses: actions/cache/save@v4
         with:
           key: ${{ runner.os }}-${{ matrix.compiler }}-${{ github.sha }}
           path: ~/.cabal/store

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Revision history for lifted-async
 
+## Unreleased
+
+* Drop support for GHC 7
+* Allow base-4.22
+
 ## v0.10.2.7 - 2024-11-03
 
 * Allow base-4.21, tasty-bench-0.4, bump Haskell CI to GHC 9.12.0 ([#46](https://github.com/maoe/lifted-async/pull/46))

--- a/lifted-async.cabal
+++ b/lifted-async.cabal
@@ -62,10 +62,8 @@ test-suite test-lifted-async
   ghc-options: -Wall -threaded
   build-depends:
       base
-    , HUnit
     , lifted-async
     , lifted-base
-    , monad-control
     , mtl
     , tasty
     , tasty-expected-failure < 0.13
@@ -80,9 +78,7 @@ test-suite regression-tests
   ghc-options: -Wall -threaded
   build-depends:
       base
-    , async
     , lifted-async
-    , mtl
     , tasty-hunit >= 0.9 && < 0.11
     , tasty-th
   default-language: Haskell2010
@@ -96,7 +92,6 @@ benchmark benchmark-lifted-async
       base
     , async
     , tasty-bench < 0.5
-    , deepseq
     , lifted-async
   default-language: Haskell2010
 
@@ -109,7 +104,6 @@ benchmark benchmark-lifted-async-threaded
       base
     , async
     , tasty-bench < 0.5
-    , deepseq
     , lifted-async
   default-language: Haskell2010
 

--- a/lifted-async.cabal
+++ b/lifted-async.cabal
@@ -12,10 +12,11 @@ copyright:           Copyright (C) 2012-2024 Mitsutoshi Aoe
 category:            Concurrency
 build-type:          Simple
 tested-with:
-  GHC == 9.12.0
-  GHC == 9.10.1
-  GHC == 9.8.2
-  GHC == 9.6.6
+  GHC == 9.14.1
+  GHC == 9.12.2
+  GHC == 9.10.2
+  GHC == 9.8.4
+  GHC == 9.6.7
   GHC == 9.4.8
   GHC == 9.2.8
   GHC == 9.0.2
@@ -35,21 +36,18 @@ description:
   instance of 'MonadBase' or 'MonadBaseControl'.
 
 library
+  hs-source-dirs: src
   exposed-modules:
     Control.Concurrent.Async.Lifted
     Control.Concurrent.Async.Lifted.Safe
   build-depends:
-      base >= 4.5 && < 4.22
+      base >= 4.9 && < 4.23
     , async >= 2.2 && < 2.3
     , lifted-base >= 0.2 && < 0.3
     , transformers-base >= 0.4 && < 0.5
     , monad-control == 1.0.*
-  if impl(ghc >= 7.8)
-    build-depends: constraints >= 0.2 && < 0.15
-  else
-    build-depends: constraints >= 0.2 && < 0.6
+    , constraints >= 0.2 && < 0.15
   ghc-options: -Wall
-  hs-source-dirs: src
   default-language: Haskell2010
 
 test-suite test-lifted-async

--- a/src/Control/Concurrent/Async/Lifted.hs
+++ b/src/Control/Concurrent/Async/Lifted.hs
@@ -86,13 +86,7 @@ import Control.Monad.Trans.Control
 import qualified Control.Concurrent.Async as A
 import qualified Control.Exception.Lifted as E
 
-#if defined(__GLASGOW_HASKELL__) && __GLASGOW_HASKELL__ < 710
-import Data.Foldable
-import Data.Traversable
-#endif
-#if !MIN_VERSION_base(4, 8, 0)
-import Data.Monoid (Monoid(mappend, mempty))
-#elif MIN_VERSION_base(4, 9, 0) && !MIN_VERSION_base(4, 13, 0)
+#if !MIN_VERSION_base(4, 11, 0)
 import Data.Semigroup (Semigroup((<>)))
 #endif
 
@@ -460,7 +454,6 @@ instance MonadBaseControl IO m => Alternative (Concurrently m) where
   Concurrently as <|> Concurrently bs =
     Concurrently $ either id id <$> race as bs
 
-#if MIN_VERSION_base(4, 9, 0)
 instance (MonadBaseControl IO m, Semigroup a) =>
   Semigroup (Concurrently m a) where
     (<>) = liftA2 (<>)
@@ -469,11 +462,6 @@ instance (MonadBaseControl IO m, Semigroup a, Monoid a) =>
   Monoid (Concurrently m a) where
     mempty = pure mempty
     mappend = (<>)
-#else
-instance (MonadBaseControl IO m, Monoid a) => Monoid (Concurrently m a) where
-  mempty = pure mempty
-  mappend = liftA2 mappend
-#endif
 
 sequenceEither :: MonadBaseControl IO m => Either e (StM m a) -> m (Either e a)
 sequenceEither = either (return . Left) (fmap Right . restoreM)

--- a/src/Control/Concurrent/Async/Lifted/Safe.hs
+++ b/src/Control/Concurrent/Async/Lifted/Safe.hs
@@ -92,13 +92,7 @@ import qualified Control.Concurrent.Async as A
 
 import qualified Control.Concurrent.Async.Lifted as Unsafe
 
-#if defined(__GLASGOW_HASKELL__) && __GLASGOW_HASKELL__ < 710
-import Data.Foldable
-import Data.Traversable
-#endif
-#if !MIN_VERSION_base(4, 8, 0)
-import Data.Monoid (Monoid(mappend, mempty))
-#elif MIN_VERSION_base(4, 9, 0) && !MIN_VERSION_base(4, 13, 0)
+#if !MIN_VERSION_base(4, 11, 0)
 import Data.Semigroup (Semigroup((<>)))
 #endif
 
@@ -438,7 +432,6 @@ instance (MonadBaseControl IO m, Forall (Pure m)) =>
         \\ (inst :: Forall (Pure m) :- Pure m a)
         \\ (inst :: Forall (Pure m) :- Pure m b)
 
-#if MIN_VERSION_base(4, 9, 0)
 instance (MonadBaseControl IO m, Semigroup a, Forall (Pure m)) =>
   Semigroup (Concurrently m a) where
     (<>) = liftA2 (<>)
@@ -447,9 +440,3 @@ instance (MonadBaseControl IO m, Semigroup a, Monoid a, Forall (Pure m)) =>
   Monoid (Concurrently m a) where
     mempty = pure mempty
     mappend = (<>)
-#else
-instance (MonadBaseControl IO m, Monoid a, Forall (Pure m)) =>
-  Monoid (Concurrently m a) where
-    mempty = pure mempty
-    mappend = liftA2 mappend
-#endif

--- a/tests/Test/Async/Common.hs
+++ b/tests/Test/Async/Common.hs
@@ -1,12 +1,9 @@
-{-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE FlexibleContexts #-}
 module Test.Async.Common
   ( value
   , TestException(..)
   , module X
   ) where
-
-import Data.Typeable
 
 import Control.Exception.Lifted
 import Test.Tasty as X
@@ -17,6 +14,6 @@ value :: Int
 value = 42
 
 data TestException = TestException
-  deriving (Eq, Show, Typeable)
+  deriving (Eq, Show)
 
 instance Exception TestException

--- a/tests/Test/Async/IO.hs
+++ b/tests/Test/Async/IO.hs
@@ -9,11 +9,7 @@ import Data.Maybe (isJust, isNothing)
 import Control.Concurrent.Lifted
 import Control.Exception.Lifted as E
 
-#if MIN_VERSION_monad_control(1, 0, 0)
 import Control.Concurrent.Async.Lifted.Safe
-#else
-import Control.Concurrent.Async.Lifted
-#endif
 import Test.Async.Common
 
 ioTestGroup :: TestTree

--- a/tests/Test/Async/Reader.hs
+++ b/tests/Test/Async/Reader.hs
@@ -11,11 +11,7 @@ import Control.Concurrent.Lifted
 import Control.Exception.Lifted as E
 import Test.Tasty.ExpectedFailure
 
-#if MIN_VERSION_monad_control(1, 0, 0)
 import Control.Concurrent.Async.Lifted.Safe
-#else
-import Control.Concurrent.Async.Lifted
-#endif
 import Test.Async.Common
 
 readerTestGroup :: TestTree

--- a/tests/TestSuite.hs
+++ b/tests/TestSuite.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE ScopedTypeVariables,DeriveDataTypeable #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 module Main where
 import Test.Tasty (defaultMain, testGroup)
 


### PR DESCRIPTION
`deriving Typeable` now throws a warning and is entirely obsolete for
GHC 8, so we drop support for GHC 7 (anyway not testable via CI anymore).
